### PR TITLE
added configuration option to define pod name

### DIFF
--- a/src/main/groovy/org/j2objcgradle/gradle/J2objcConfig.groovy
+++ b/src/main/groovy/org/j2objcgradle/gradle/J2objcConfig.groovy
@@ -36,9 +36,16 @@ class J2objcConfig {
     J2objcConfig(Project project) {
         assert project != null
         this.project = project
+        this.podName = project.name
     }
 
     private J2objcConfig(){}
+
+    String podName
+
+    void podName(String podName) {
+        this.podName = podName
+    }
 
     boolean skipTests = false
 

--- a/src/main/groovy/org/j2objcgradle/gradle/tasks/FrameworkTask.groovy
+++ b/src/main/groovy/org/j2objcgradle/gradle/tasks/FrameworkTask.groovy
@@ -39,20 +39,21 @@ class FrameworkTask extends DefaultTask {
 
     static File headerFile(Project project, boolean test)
     {
-        String specName = podspecName(test)
+        String specName = podspecName(project, test)
         File podspecFile = new File(project.buildDir, "${specName}.h")
         return podspecFile
     }
 
     static File configFile(Project project, boolean test, String extension)
     {
-        String specName = podspecName(test)
+        String specName = podspecName(project, test)
         File podspecFile = new File(project.projectDir, "${specName}.${extension}")
         return podspecFile
     }
 
-    static String podspecName(boolean test) {
-        test ? "testj2objclib" : "j2objclib"
+    static String podspecName(Project project, boolean test) {
+        def spec = J2objcConfig.from(project)
+        test ? "${spec.podName}Test" : spec.podName
     }
 
     private List<J2objcDependency> dependencyList(boolean testBuild) {
@@ -81,7 +82,7 @@ class FrameworkTask extends DefaultTask {
         if(test && j2objcConfig.skipTests)
             return
 
-        String specName = podspecName(test)
+        String specName = podspecName(project, test)
         File podspecFile = podspecFile(project, test)
 
         List<File> objcFolders = new ArrayList<>()

--- a/src/test/kotlin/org/j2objcgradle/gradle/J2objcConfigTest.kt
+++ b/src/test/kotlin/org/j2objcgradle/gradle/J2objcConfigTest.kt
@@ -127,10 +127,12 @@ class J2objcConfigTest : BasicTestBase() {
     fun testManagePod()
     {
         writeRunCustomConfig(config = """
+    podName "custompodname"
     mainFramework{
         managePod "ios"
     }
         """)
+
     }
 
 

--- a/testprojects/basicjava/ios/Podfile
+++ b/testprojects/basicjava/ios/Podfile
@@ -7,5 +7,5 @@ target 'ios' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'j2objclib', :path => '..'
+  pod 'custompodname', :path => '..'
 end


### PR DESCRIPTION
Hey,

I made this modification to enable the consumer project to specify the name of the output pod, so multiple projects can have different names instead of a single generic name.